### PR TITLE
Updating admin permissions on Grav CLI

### DIFF
--- a/grav-setup.yml
+++ b/grav-setup.yml
@@ -49,7 +49,7 @@
 
     - name: Add admin user
       shell:
-        "cd /var/www/html && bin/plugin login add-user -u admin -p $(curl -s 169.254.169.254/latest/meta-data/instance-id)_Grav -n -P a"
+        "cd /var/www/html && bin/plugin login add-user -u admin -p $(curl -s 169.254.169.254/latest/meta-data/instance-id)_Grav -n -P b"
 
     - name: Set appropriate permissions
       file:

--- a/grav-setup.yml
+++ b/grav-setup.yml
@@ -49,7 +49,7 @@
 
     - name: Add admin user
       shell:
-        "cd /var/www/html && bin/plugin login add-user -u admin -p $(curl -s 169.254.169.254/latest/meta-data/instance-id)_Grav -n"
+        "cd /var/www/html && bin/plugin login add-user -u admin -p $(curl -s 169.254.169.254/latest/meta-data/instance-id)_Grav -n -P a"
 
     - name: Set appropriate permissions
       file:


### PR DESCRIPTION
Grav updated their auth plugin to accept different arguments. This adjustment should fix the username/password issue seen on latest AMIs.